### PR TITLE
Document user-configurable settings and configure PyPI distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE.txt README.md pytest.ini tox.ini
+recursive-include tests *
+global-exclude *.py[co]

--- a/README.md
+++ b/README.md
@@ -10,23 +10,28 @@ Use pycallnumber in your library's Python projects to parse, model, and manipula
 
 ### Requirements
 
-  * Python 2
-    * Python 2.7 and future
-  * OR Python 3, >= 3.4
+  * Python 2.7, 3.4, 3.5, or 3.6
 
 ### Setup
 
-Download the repository to a project directory like `pycallnumber`:
+Installing to a [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) using pip is recommended.
 
 ```sh
-$ git clone https://github.com/unt-libraries/pycallnumber.git pycallnumber
+$ pip install -U pip        # Do this if the install fails at first
+$ pip install pycallnumber
+```
+
+#### Development setup and testing
+
+If you want to contribute to pycallnumber, you'll want to fork the project and then download and install your fork from GitHub. E.g.:
+
+```sh
+$ git clone https://github.com/[your-github-user]/pycallnumber.git pycallnumber
 ```
 or (SSH)
 ```sh
-$ git clone git@github.com:unt-libraries/pycallnumber.git pycallnumber
+$ git clone git@github.com:[your-github-user]/pycallnumber.git pycallnumber
 ```
-
-Installing to a [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) using pip is recommended.
 
 ```sh
 $ pip install ./pycallnumber
@@ -42,9 +47,9 @@ $ cd pycallnumber
 $ python setup.py install
 ```
 
-### Tests
+##### Running tests
 
-(The below commands assume you're in the repository root.)
+(The below commands assume you've installed from GitHub and are in the repository root.)
 
 You can use [pytest](http://doc.pytest.org/) to run tests in your current Python environment.
 ```sh
@@ -52,7 +57,7 @@ $ pip install pytest
 $ py.test
 ```
 
-Or if you're planning to develop on `pycallnumber`, you can use [tox](https://tox.readthedocs.io/) to run tests against multiple Python versions.
+Or you can use [tox](https://tox.readthedocs.io/) to run tests against multiple Python versions.
 ```sh
 $ pip install tox
 $ tox               # run tests against all configured environments

--- a/pycallnumber/__init__.py
+++ b/pycallnumber/__init__.py
@@ -21,11 +21,19 @@ from . import units
 from . import utils
 from .factories import callnumber, cnrange, cnset
 
-__version__ = '0.1'
-__author__ = 'Jason Thomale'
 __all__ = [settings, CallNumberError, CallNumberWarning,
            InvalidCallNumberStringError, SettingsError, MethodError,
            OptionsError, UtilsError, RangeSetError, BadRange, Options,
            ObjectWithOptions, Template, SimpleTemplate, CompoundTemplate,
            Grouping, Unit, SimpleUnit, CompoundUnit, RangeSet, units,
            utils, callnumber, cnrange, cnset]
+
+__version__ = '0.1.1'
+__name__ = 'pycallnumber'
+__url__ = 'https://github.com/unt-libraries/pycallnumber'
+__description__ = 'A Python library for parsing call numbers.'
+__license__ = 'BSD'
+__author__ = 'Jason Thomale'
+__author_email__ = 'jason.thomale@unt.edu'
+__maintainer__ = 'University of North Texas Libraries'
+__keywords__ = 'python, callnumber, callnumbers, call number, call numbers'

--- a/pycallnumber/factories.py
+++ b/pycallnumber/factories.py
@@ -14,23 +14,19 @@ def callnumber(cnstr, name='', useropts=None, unittypes=None):
     types.
 
     Use ``name`` to specify the name of the resulting Unit object.
-    Defaults to an empty string. It generally isn't import that this is
-    specified, unless your code makes heavy use of the Unit.name.
+    Defaults to an empty string. It generally isn't important that this
+    is specified, unless your code makes heavy use of the Unit.name.
 
     Use ``useropts`` to pass sets of Unit-specific options to the
-    resulting Unit object. Defaults are found in
-    settings.DEFAULT_UNIT_OPTIONS. You can set this variable to
-    override the defaults globally, or pass your own dict to override
-    on a per-call basis.
+    resulting Unit object (as a dict).
 
     Use ``unittypes`` to specify the list of valid Unit types to use
     to generate Unit objects. The first Unit type found that matches
     the given call number string is returned, so order matters.
-    Defaults are found in settings.DEFAULT_UNIT_TYPES. Set this
-    variable to override defaults globally, or pass your own list to
-    override on a per-call basis.
+    Defaults are found in settings.DEFAULT_UNIT_TYPES. Pass your own
+    list to override the default.
     """
-    useropts = useropts or settings.DEFAULT_UNIT_OPTIONS
+    useropts = useropts or {}
     utypes = unittypes or [load_class(t) for t in settings.DEFAULT_UNIT_TYPES]
     cn_unit = create_unit(cnstr, utypes, useropts, name)
     if cn_unit is None:
@@ -68,10 +64,10 @@ def cnrange(start, end, startname='', endname='', useropts=None,
 
     Use the ``rangesettype`` kwarg to specify what type of object you
     want to generate. The default is settings.DEFAULT_RANGESET_TYPE,
-    which defaults to RangeSet. Override this if you want to provide
-    your own class. (It must be a subclass of RangeSet.)
+    which defaults to RangeSet. If you provide your own class, it must
+    be a subclass of RangeSet.
     """
-    useropts = useropts or settings.DEFAULT_UNIT_OPTIONS
+    useropts = useropts or {}
     utypes = unittypes or [load_class(t) for t in settings.DEFAULT_UNIT_TYPES]
     rangesettype = rangesettype or load_class(settings.DEFAULT_RANGESET_TYPE)
     try:
@@ -124,7 +120,7 @@ def cnset(ranges, names=None, useropts=None, unittypes=None,
     caught while trying to parse it.
 
     """
-    useropts = useropts or settings.DEFAULT_UNIT_OPTIONS
+    useropts = useropts or {}
     utypes = unittypes or [load_class(t) for t in settings.DEFAULT_UNIT_TYPES]
     rangesettype = rangesettype or load_class(settings.DEFAULT_RANGESET_TYPE)
     rangeset = rangesettype()

--- a/pycallnumber/settings.py
+++ b/pycallnumber/settings.py
@@ -1,5 +1,103 @@
-"""Default settings for pycallnumber package."""
+"""Default settings for pycallnumber package.
 
+This module provides packagewide defaults. Generally, you can override
+them on an individual basis by passing the appropriate parameters to
+various functions and object methods, as explained below.
+
+DO NOT override them by changing these values directly.
+
+"""
+
+# ************** OVERRIDABLE UNIT OPTIONS
+# These are default options controlling unit type normalization.
+# Generally, you shouldn't have to override the defaults. But, in case
+# you do, here's what the options are and how to override them.
+#
+# Alphabetic types provide options for controlling how to normalize
+# case. Formatting types provide options for controlling whether or not
+# formatting characters appear in sort and search normalizations.
+#
+# Compound Unit types that contain an Alphabetic and/or Formatting type
+# inherit their options. AlphaNumeric types therefore have only case
+# options; AlphaSymbol types have case and formatting options, for
+# example.
+#
+# HOW TO OVERRIDE THESE
+#
+# There are four ways to override options, listed here in order of
+# strength or precedence.
+#
+# 1.  Set the relevant class attribute for a unit type to FORCE that
+#     unit type to use the particular setting. Overrides everything.
+#     Example: units.Cutter.sort_case = 'upper'
+#
+# 2.  Set the option for an individual object by passing the option via
+#     a kwarg when you initialize the object. This will override any
+#     options defaults (see 4) but NOT forced class attributes (see 1).
+#     Example: units.Cutter('c35', sort_case='upper')
+#
+# 3.  If using one of the factories.py functions, such as `callnumber`,
+#     you can pass options in using a dict in the `useropts` kwarg.
+#     This passes your options on when the correct unit object is
+#     initialized, as in option 2a.
+#
+# 4.  Set or change the default value for an option by setting the
+#     relevant option in the `options_defaults` class attribute (dict).
+#     This changes the default for that unit type, which is used IF
+#     nothing else overrides it. Caveat: be careful that you create a
+#     copy of the `options_defaults` dict before making changes.
+#     Otherwise you will end up changing defaults for other unit types.
+#     Example: units.Cutter.options_defaults = units.Cutter\
+#                 .options_defaults.copy()
+#              units.Cutter.options_defaults['sort_case'] = 'upper'
+#
+# ALPHABETIC `CASE` Options
+# -------------------------
+# Options are: `display_case` (controls case when using the `for_print`
+# unit method), `search_case` (controls case when using the
+#  `for_search` unit method), and `sort_case` (controls case when using
+# the `for_sort` unit method).
+#
+# Use 'lower' for lowercase, 'upper' for uppercase, and anything
+# else for retaining the original case.
+DEFAULT_DISPLAY_CASE = ''
+DEFAULT_SEARCH_CASE = 'lower'
+DEFAULT_SORT_CASE = 'lower'
+
+# FORMATTING `USE IN` Options
+# ---------------------------
+# Options are: `use_formatting_in_search` (controls whether formatting
+# appears at all when using the `for_search` unit method) and
+# `use_formatting_in_sort` (controls whether formatting appears at all
+# when using the `for_sort` unit method).
+#
+# Use True to include formatting in a normalized string or False to
+# hide it.
+DEFAULT_USE_FORMATTING_IN_SEARCH = False
+DEFAULT_USE_FORMATTING_IN_SORT = False
+
+
+# ************** NON-OVERRIDABLE DEFAULTS
+# DEFAULT_MAX_NUMERIC_ZFILL is used by Numeric and derived classes. You
+# cannot change this directly, but if you specify that a Numeric unit
+# type has a maximum value that would require more than the default
+# number of digits, it will be adjusted accordingly for that type.
+DEFAULT_MAX_NUMERIC_ZFILL = 10
+
+
+# ************** `FACTORIES` SETTINGS
+# DEFAULT_UNIT_TYPES is used by the factories.py functions to specify
+# exactly what types of call numbers these functions should recognize.
+# You can override this setting by passing your own custom list via the
+# `unittypes` kwarg of these functions.
+#
+# Example:
+#   my_unit_list = [local_module.MyDewey, local_module.MyLC]
+#   pycallnumber.callnumber('my_string', unittypes=my_unit_list)
+#
+# Note that DEFAULT_UNIT_TYPES contains path strings. Your custom list
+# (passed to pycallnumber.callnumber via `unittypes`) should contain
+# the unit types themselves, not strings.
 DEFAULT_UNIT_TYPES = [
     'pycallnumber.units.Dewey',
     'pycallnumber.units.DeweyClass',
@@ -9,18 +107,11 @@ DEFAULT_UNIT_TYPES = [
     'pycallnumber.units.Local'
 ]
 
+# DEFAULT_RANGESET_TYPE is used by the factories.py `cnrange` and
+# `cnset` functions to determine the class that implements call number
+# ranges. If you create your own RangeSet class, you can pass the type
+# directly via the `rangesettype` kwarg.
+#
+# Note, like DEFAULT_UNIT_TYPES, DEFAULT_RANGESET_TYPE contains a path
+# string, while your `rangessettype` kwarg should be a type/class.
 DEFAULT_RANGESET_TYPE = 'pycallnumber.set.RangeSet'
-
-# Default Unit Options
-DEFAULT_DISPLAY_CASE = ''
-DEFAULT_SEARCH_CASE = 'lower'
-DEFAULT_SORT_CASE = 'lower'
-DEFAULT_USE_FORMATTING_IN_SEARCH = False
-DEFAULT_USE_FORMATTING_IN_SORT = False
-DEFAULT_MAX_NUMERIC_ZFILL = 10
-
-DEFAULT_UNIT_OPTIONS = {
-    'display_case': DEFAULT_DISPLAY_CASE,
-    'search_case': DEFAULT_SEARCH_CASE,
-    'sort_case': DEFAULT_SORT_CASE,
-}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[aliases]
+test=pytest
+
+[metadata]
+description-file = README.md
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -3,33 +3,41 @@
 import os
 import setuptools
 
-
-name = 'pycallnumber'
-url = 'https://github.com/unt-libraries/pycallnumber'
-description = 'A Python library for parsing call numbers.'
-package_metadata = {}
-with open(os.path.join(name, '__init__.py')) as fh:
+meta = {}
+with open(os.path.join('pycallnumber', '__init__.py')) as fh:
     variables = [l.split(' = ') for l in fh if l.startswith('__')]
     for var in variables:
-        package_metadata[var[0].strip('_')] = var[-1].strip('"\'\n')
+        meta[var[0].strip('_')] = var[-1].strip('"\'\n')
 
 setuptools.setup(
-    name=name,
-    author=package_metadata['author'],
-    author_email='jason.thomale@unt.edu',
-    version=package_metadata['version'],
-    url=url,
-    license='BSD',
-    description=description,
-    long_description=('Visit {} for the latest documentation.'.format(url)),
+    name=meta['name'],
+    author=meta['author'],
+    author_email=meta['author_email'],
+    version=meta['version'],
+    url=meta['url'],
+    license=meta['license'],
+    description=meta['description'],
+    long_description=('Visit {} for the latest documentation.'.format(
+                       meta['url'])),
+    maintainer=meta['maintainer'],
+    keywords=meta['keywords'],
     packages=setuptools.find_packages(),
     install_requires=[
         'future;python_version=="2.7"'
+    ],
+    setup_requires=[
+        'pytest-runner'
+    ],
+    tests_require=[
+        'pytest'
     ],
     classifiers=[
         'Intended Audience :: Education',
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ]
 )


### PR DESCRIPTION
Resolves #18 
Resolves #19 

The PyPI distribution for `pycallnumber` is now up; `pip install pycallnumber` now works!

This set of changes also adds some documentation to help clear up some of the more mysterious settings/options, which 99% of people won't ever need to change.