### PR TITLE
Fix "from pycallnumber import *"

### DIFF
--- a/pycallnumber/__init__.py
+++ b/pycallnumber/__init__.py
@@ -21,14 +21,15 @@ from . import units
 from . import utils
 from .factories import callnumber, cnrange, cnset
 
-__all__ = [settings, CallNumberError, CallNumberWarning,
-           InvalidCallNumberStringError, SettingsError, MethodError,
-           OptionsError, UtilsError, RangeSetError, BadRange, Options,
-           ObjectWithOptions, Template, SimpleTemplate, CompoundTemplate,
-           Grouping, Unit, SimpleUnit, CompoundUnit, RangeSet, units,
-           utils, callnumber, cnrange, cnset]
+__all__ = ['settings', 'CallNumberError', 'CallNumberWarning',
+           'InvalidCallNumberStringError', 'SettingsError', 'MethodError',
+           'OptionsError', 'UtilsError', 'RangeSetError', 'BadRange',
+           'Options', 'ObjectWithOptions', 'Template', 'SimpleTemplate',
+           'CompoundTemplate', 'Grouping', 'Unit', 'SimpleUnit',
+           'CompoundUnit', 'RangeSet', 'units',
+           'utils', 'callnumber', 'cnrange', 'cnset']
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 __name__ = 'pycallnumber'
 __url__ = 'https://github.com/unt-libraries/pycallnumber'
 __description__ = 'A Python library for parsing call numbers.'


### PR DESCRIPTION
Importing with
```code
from pycallnumber import *
```
results in TypeError:
```
Connected to pydev debugger (build 182.4505.26)
raceback (most recent call last):
  File "callnumber.py", line 3, in <module>
    from pycallnumber import *
  File "<frozen importlib._bootstrap>", line 1031, in _handle_fromlist
  File "<frozen importlib._bootstrap>", line 1026, in _handle_fromlist
TypeError: Item in pycallnumber.__all__ must be str, not module
```

If present, __all__ must be a sequence of strings.[1]

- Changed items in __all__ to strings.
- Ran tests (passed).

[1] See section https://docs.python.org/3/reference/simple_stmts.html#the-import-statement


