### PR TITLE
Python 3.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,flake8
+envlist=py27,py34,py35,py36,py37,flake8
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
Tests pass under Python 3.7, so seemed useful to make that explicit.

NB: Lots of deprecation warnings in the test output.