### PR TITLE
Finish fixing all star imports

### DIFF
--- a/pycallnumber/__init__.py
+++ b/pycallnumber/__init__.py
@@ -28,7 +28,7 @@ __all__ = ['settings', 'CallNumberError', 'CallNumberWarning',
            'CompoundUnit', 'RangeSet', 'units',
            'utils', 'callnumber', 'cnrange', 'cnset']
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __name__ = 'pycallnumber'
 __url__ = 'https://github.com/unt-libraries/pycallnumber'
 __description__ = 'A Python library for parsing call numbers.'

--- a/pycallnumber/__init__.py
+++ b/pycallnumber/__init__.py
@@ -5,7 +5,6 @@ Dewey Decimal, US SuDocs, and others)--parse them, normalize them, sort
 them.
 """
 
-from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from . import settings

--- a/pycallnumber/units/__init__.py
+++ b/pycallnumber/units/__init__.py
@@ -10,7 +10,8 @@ from .callnumbers.parts import Cutter, Edition, Item
 from .callnumbers import LC, LcClass, Dewey, DeweyClass, SuDoc, Agency,\
                         AgencyDotSeries, Local
 
-__all__ = [Alphabetic, Numeric, Formatting, AlphaNumeric, AlphaSymbol,
-           NumericSymbol, AlphaNumericSymbol, Number, OrdinalNumber,
-           DateString, Cutter, Edition, Item, LC, LcClass, Dewey, DeweyClass,
-           SuDoc, Agency, AgencyDotSeries, Local]
+__all__ = ['Alphabetic', 'Numeric', 'Formatting', 'AlphaNumeric',
+           'AlphaSymbol', 'NumericSymbol', 'AlphaNumericSymbol', 'Number',
+           'OrdinalNumber', 'DateString', 'Cutter', 'Edition', 'Item', 'LC',
+           'LcClass', 'Dewey', 'DeweyClass', 'SuDoc', 'Agency',
+           'AgencyDotSeries', 'Local']

--- a/pycallnumber/units/callnumbers/__init__.py
+++ b/pycallnumber/units/callnumbers/__init__.py
@@ -6,5 +6,5 @@ from .lc import LC, LcClass
 from .sudoc import SuDoc, Agency, AgencyDotSeries
 from .local import Local
 
-__all__ = [Dewey, DeweyClass, LC, LcClass, SuDoc, Agency, AgencyDotSeries,
-           Local]
+__all__ = ['Dewey', 'DeweyClass', 'LC', 'LcClass', 'SuDoc', 'Agency',
+           'AgencyDotSeries', 'Local']

--- a/pycallnumber/units/dates/__init__.py
+++ b/pycallnumber/units/dates/__init__.py
@@ -3,4 +3,4 @@ from __future__ import absolute_import
 
 from .datestring import DateString
 
-__all__ = [DateString]
+__all__ = ['DateString']

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from context import unit as un

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -54,6 +54,14 @@ _100a = AnotherFactoryTestType('100 A')
 
 # Tests
 
+def test_star_imports():
+    """Star imports should work without raising errors."""
+    from context import pycallnumber
+    all_imports = __import__('pycallnumber', globals(), locals(), ['*'])
+    assert all_imports.callnumber
+    assert len(all_imports.__all__) == len(pycallnumber.__all__)
+
+
 @pytest.mark.callnumber_factory
 def test_callnumber_selects_correct_type_using_unittype_kwarg():
     """Calls to the ``callnumber`` factory should return the correct

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -717,6 +717,35 @@ SEARCH_TEST_PARAMS = generate_params(UNITS_DATA, 'search')
 
 # Tests
 
+def test_units_star_imports():
+    """Star imports for the ``units`` package should work without
+    raising errors."""
+    from context import pycallnumber
+    all_imp = __import__('pycallnumber.units', globals(), locals(), ['*'])
+    assert all_imp.Alphabetic
+    assert len(all_imp.__all__) == len(pycallnumber.units.__all__)
+
+
+def test_units_callnumbers_star_imports():
+    """Star imports for the ``units.callnumbers`` package should work
+    without raising errors."""
+    from context import pycallnumber
+    all_imp = __import__('pycallnumber.units.callnumbers', globals(),
+                         locals(), ['*'])
+    assert all_imp.LC
+    assert len(all_imp.__all__) == len(pycallnumber.units.callnumbers.__all__)
+
+
+def test_units_dates_star_imports():
+    """Star imports for the ``units.dates`` package should work without
+    raising errors."""
+    from context import pycallnumber
+    all_imp = __import__('pycallnumber.units.dates', globals(), locals(),
+                         ['*'])
+    assert all_imp.DateString
+    assert len(all_imp.__all__) == len(pycallnumber.units.dates.__all__)
+
+
 @pytest.mark.parametrize('tclass, tstr', VALID_TEST_PARAMS)
 def test_Unit_validate_is_valid(tclass, tstr):
     """The test string should validate when a Unit subclass is

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from context import units as u


### PR DESCRIPTION
After releasing changes earlier this morning for 0.1.3 on PyPI I was doing ad-hoc testing and realized there were still two problems with star imports that hadn't been caught:
1. The `__all__` definitions for sub-packages (`pycallnumber.units`, `pycallnumber.units.callnumbers`, and `pycallnumber.units.dates`) needed to be updated to lists of strings, as well.
2. Python 2 didn't like star imports because the main __init__.py file imported `unicode_literals` from `__future__`; so the strings in `__all__` ended up being unicode objects instead of strings, and Python 2 wants them to be strings. Removing `unicode_literals` from this file (and the relevant `test` files, once I created the tests) fixed the problem and didn't seem to have any bad side-effects.

I also added tests to test importing * for the main package and each of the sub-packages, which I should have done in the first place...