### PR TITLE
Resolve deprecation warnings during tests

### DIFF
--- a/pycallnumber/utils.py
+++ b/pycallnumber/utils.py
@@ -35,7 +35,13 @@ def memoize(function):
     values. Order of args in the key will follow the order in the
     function's signature, even if kwargs are called out of order.
     """
-    argnames, _, _, _ = inspect.getargspec(function)
+    try:
+        sig = inspect.signature(function)
+    except AttributeError:
+        argnames, _, _, _ = inspect.getargspec(function)
+    else:
+        argnames = [arg for arg in sig.parameters.keys()]
+
     if len(argnames) > 0 and argnames[0] in ('self', 'cls'):
         function_is_method = True
         argnames = argnames[1:]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -87,12 +87,13 @@ def generate_params(data, param_type):
         for values in param_set:
             if not isinstance(values, tuple):
                 values = (values,)
-            params = (kind,) + values
-            for m in markers:
-                params = m(params)
-            flattened.append(params)
+            inner_params_list = (kind,) + values
+            flattened.append(pytest.param(*inner_params_list, marks=markers))
     return flattened
 
 
-def mark_params(params, marker):
-    return [marker(p) for p in params]
+def mark_params(param_sets, markers):
+    try:
+        return [pytest.param(*p.values, marks=markers) for p in param_sets]
+    except AttributeError:
+        return [pytest.param(*p, marks=markers) for p in param_sets]


### PR DESCRIPTION
This update resolves the two issues leading to deprecation warnings during testing.

1. The `utils.memoize` function now uses `inspect.signature` if available (Python 3), and falls back on `inspect.getargspec` (Python 2, deprecated in 3.7, I guess?) otherwise.

2. The `tests.helpers` functions that generated parameters for tests were using a deprecated method for marking parameters with custom marks. Updated the generator functions to use the new method, which resolved those thousands of warnings.